### PR TITLE
Bugfix/#15 make chip combobox null safe

### DIFF
--- a/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
+++ b/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
@@ -29,13 +29,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import com.vaadin.flow.component.AbstractCompositeField;
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
@@ -52,8 +51,7 @@ import com.vaadin.flow.shared.Registration;
  * @author DL
  * @author AB
  */
-public class ChipComboBox<T> extends Composite<VerticalLayout> implements
-	HasValue<ComponentValueChangeEvent<ChipComboBox<T>, Collection<T>>, Collection<T>>,
+public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, ChipComboBox<T>, Collection<T>> implements
 	HasStyle,
 	HasSize
 {
@@ -63,7 +61,7 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	 */
 	protected ComboBox<T> cbAvailableItems = new ComboBox<>();
 	protected FlexLayout chipsContainer = new FlexLayout();
-
+	
 	/*
 	 * Suppliers / Configuration
 	 */
@@ -79,6 +77,7 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	
 	public ChipComboBox()
 	{
+		super(null);
 		this.initUI();
 	}
 	
@@ -87,7 +86,6 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 		final Style chipsContainerStyle = this.chipsContainer.getStyle();
 		chipsContainerStyle.set("flex-flow", "wrap");
 		chipsContainerStyle.set("flex-direction", "row");
-		
 		
 		this.getContent().setPadding(false);
 		this.getContent().setSpacing(false);
@@ -146,6 +144,7 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	
 	/**
 	 * Updates/Rebuilds the UI form the fields
+	 * 
 	 * @implNote Will not fire a {@link ValueChangeEvent}
 	 */
 	public void updateUI()
@@ -157,7 +156,7 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	protected void updateSelectedChips()
 	{
 		this.chipsContainer.removeAll();
-		this.chipsContainer.add(this.selectedItems.values().toArray(new ChipComponent[] {}));
+		this.chipsContainer.add(this.selectedItems.values().toArray(new ChipComponent[]{}));
 	}
 	
 	protected void updateAvailableItems()
@@ -168,7 +167,7 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	}
 	
 	///////////////////////////////////////////////////////////////////////////
-	// setters + getters  //
+	// setters + getters //
 	///////////////////////
 	
 	public Supplier<ChipComponent> getChipsSupplier()
@@ -228,7 +227,7 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	{
 		return this.cbAvailableItems.getPlaceholder();
 	}
-
+	
 	public ChipComboBox<T> withPlaceholder(final String placeholder)
 	{
 		Objects.requireNonNull(placeholder);
@@ -253,18 +252,11 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 		}
 		return this;
 	}
-
+	
 	@Override
 	public void setValue(final Collection<T> value)
 	{
-		final Collection<T> oldValues = new LinkedHashSet<>(this.selectedItems.keySet());
-		
-		this.selectedItems.clear();
-		value.forEach(this::addNewItem);
-		
-		this.fireValueChange(oldValues, false);
-		
-		this.updateUI();
+		this.setPresentationValue(value);
 	}
 
 	@Override
@@ -275,67 +267,90 @@ public class ChipComboBox<T> extends Composite<VerticalLayout> implements
 	
 	protected void fireValueChange(final Collection<T> oldValue, final boolean fromClient)
 	{
-		 ComponentUtil.fireEvent(this, new ComponentValueChangeEvent<>(this, this, oldValue, fromClient));
+		ComponentUtil.fireEvent(this, new ComponentValueChangeEvent<>(this, this, oldValue, fromClient));
 	}
-
+	
 	@Override
 	@SuppressWarnings("unchecked")
 	public Registration addValueChangeListener(
 		final ValueChangeListener<? super ComponentValueChangeEvent<ChipComboBox<T>, Collection<T>>> listener)
 	{
 		@SuppressWarnings("rawtypes")
-		final
-        ComponentEventListener componentListener = event -> {
-            final ComponentValueChangeEvent<ChipComboBox<T>, Collection<T>> valueChangeEvent = (ComponentValueChangeEvent<ChipComboBox<T>, Collection<T>>) event;
-            listener.valueChanged(valueChangeEvent);
-        };
-        return ComponentUtil.addListener(this,
-                ComponentValueChangeEvent.class, componentListener);
+		final ComponentEventListener componentListener = event ->
+		{
+			final ComponentValueChangeEvent<ChipComboBox<T>, Collection<T>> valueChangeEvent =
+				(ComponentValueChangeEvent<ChipComboBox<T>, Collection<T>>)event;
+			listener.valueChanged(valueChangeEvent);
+		};
+		return ComponentUtil.addListener(
+			this,
+			ComponentValueChangeEvent.class,
+			componentListener);
 	}
-
+	
 	@Override
 	public void setReadOnly(final boolean readOnly)
 	{
 		this.cbAvailableItems.setReadOnly(readOnly);
 		this.selectedItems.values().forEach(comp -> comp.setReadonly(readOnly));
 	}
-
+	
 	@Override
 	public boolean isReadOnly()
 	{
 		return this.cbAvailableItems.isReadOnly();
 	}
-
+	
 	@Override
 	public void setRequiredIndicatorVisible(final boolean requiredIndicatorVisible)
 	{
 		this.cbAvailableItems.setRequiredIndicatorVisible(requiredIndicatorVisible);
 	}
-
+	
 	@Override
 	public boolean isRequiredIndicatorVisible()
 	{
 		return this.cbAvailableItems.isRequiredIndicatorVisible();
 	}
-
+	
 	/**
 	 * Returns the {@link ComboBox} which contains the available items.<br/>
 	 * NOTE: If the contents of the {@link ComboBox} are modified from the outside this component may break
+	 * 
 	 * @return
 	 */
 	public ComboBox<T> getCbAvailableItems()
 	{
 		return this.cbAvailableItems;
 	}
-
+	
 	/**
 	 * Returns the {@link FlexLayout} with the select items (as {@link ChipComponent}s).<br/>
 	 * NOTE: If the contents of the {@link FlexLayout} are modified from the outside this component may break
+	 * 
 	 * @return
 	 */
 	public FlexLayout getChipsContainer()
 	{
 		return this.chipsContainer;
+	}
+	
+	@Override
+	protected void setPresentationValue(final Collection<T> value)
+	{
+		final Collection<T> oldValues = new LinkedHashSet<>(this.selectedItems.keySet());
+		
+		this.selectedItems.clear();
+		
+		if(value != null)
+		{
+			value.forEach(this::addNewItem);
+		}
+		
+		this.fireValueChange(oldValues, false);
+		
+		this.updateUI();
+		
 	}
 	
 }

--- a/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
+++ b/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
@@ -444,6 +444,20 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		this.cbAvailableItems.setRequiredIndicatorVisible(requiredIndicatorVisible);
 	}
 
+	
+	@Override
+	public void setValue(final Collection<T> value)
+	{
+		this.selectedComponents.clear();
+		final ArrayList<T> newValue = new ArrayList<>();
+		if(value != null)
+		{
+			this.updateValues(newValue, true);
+		}
+		this.updateValues(newValue, true);
+		this.updateUI();
+	}
+	
 	/*
 	 * UI-Components
 	 */

--- a/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
+++ b/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
@@ -22,7 +22,6 @@ package software.xdev.vaadin.chips;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -76,8 +75,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 
 	public ChipComboBox()
 	{
-		super(Collections.emptyList());
-
+		super(new ArrayList<>());
 		this.initUI();
 		this.initListeners();
 	}
@@ -448,14 +446,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	@Override
 	public void setValue(final Collection<T> value)
 	{
-		this.selectedComponents.clear();
-		final ArrayList<T> newValue = new ArrayList<>();
-		if(value != null)
-		{
-			this.updateValues(newValue, true);
-		}
-		this.updateValues(newValue, true);
-		this.updateUI();
+		super.setValue(Objects.requireNonNull(value));
 	}
 	
 	/*

--- a/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
+++ b/vaadin-chip-combobox/src/main/java/software/xdev/vaadin/chips/ChipComboBox.java
@@ -54,70 +54,70 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	HasStyle,
 	HasSize
 {
-
+	
 	/*
 	 * UI-Components
 	 */
 	protected ComboBox<T> cbAvailableItems = new ComboBox<>();
 	protected FlexLayout chipsContainer = new FlexLayout();
-
+	
 	/*
 	 * Suppliers / Configuration
 	 */
 	protected Function<T, ChipComponent<T>> chipsSupplier = ChipComponent::new;
 	protected ItemLabelGenerator<T> chipItemLabelGenerator = Object::toString;
-
+	
 	/*
 	 * Fields
 	 */
 	protected final List<T> allAvailableItems = new ArrayList<>();
 	protected final List<ChipComponent<T>> selectedComponents = new ArrayList<>();
-
+	
 	public ChipComboBox()
 	{
 		super(new ArrayList<>());
 		this.initUI();
 		this.initListeners();
 	}
-
+	
 	protected void initUI()
 	{
 		final Style chipsContainerStyle = this.chipsContainer.getStyle();
 		chipsContainerStyle.set("flex-flow", "wrap");
 		chipsContainerStyle.set("flex-direction", "row");
-
+		
 		this.getContent().setPadding(false);
 		this.getContent().setSpacing(false);
 		this.setSizeUndefined();
-
+		
 		this.getContent().add(this.cbAvailableItems, this.chipsContainer);
 	}
-
+	
 	protected void initListeners()
 	{
 		this.cbAvailableItems.addValueChangeListener(this::onCbAvailableItemsValueChanged);
 	}
-
+	
 	protected void onCbAvailableItemsValueChanged(final ComponentValueChangeEvent<ComboBox<T>, T> event)
 	{
 		if(event.getValue() == null || this.isReadOnly())
 		{
 			return;
 		}
-
+		
 		this.addItem(event.getValue(), event.isFromClient());
 	}
-
+	
 	@Override
 	protected void setPresentationValue(final Collection<T> newPresentationValue)
 	{
 		/*
 		 * Update the component list
 		 */
-
+		
 		// Remove components
 		this.selectedComponents.removeIf(comp -> !newPresentationValue.contains(comp.getItem()));
-
+		
 		// Find new values and build components
 		// @formatter:off
 		final Collection<T> existingValues =
@@ -144,24 +144,24 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 			})
 			.forEach(this.selectedComponents::add);
 		// @formatter:on
-
+		
 		this.updateUI();
 	}
-
+	
 	protected void addItem(final T item, final boolean isFromClient)
 	{
 		final List<T> values = new ArrayList<>(this.getValue());
 		values.add(item);
 		this.updateValues(values, isFromClient);
 	}
-
+	
 	protected void removeItem(final T item, final boolean isFromClient)
 	{
 		final List<T> values = new ArrayList<>(this.getValue());
 		values.remove(item);
 		this.updateValues(values, isFromClient);
 	}
-
+	
 	/**
 	 * Updates the underlying values (if the newValues doesn't equals the oldValue)
 	 *
@@ -180,13 +180,13 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	{
 		final Collection<T> oldValue = this.getValue();
 		this.setModelValue(newValues, isFromClient);
-
+		
 		if(!this.valueEquals(oldValue, newValues))
 		{
 			this.setPresentationValue(newValues);
 		}
 	}
-
+	
 	/**
 	 * Updates/Rebuilds the UI from the fields
 	 *
@@ -197,20 +197,20 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		this.updateSelectedChips();
 		this.updateAvailableItems();
 	}
-
+	
 	protected void updateSelectedChips()
 	{
 		this.chipsContainer.removeAll();
 		this.chipsContainer.add(this.selectedComponents.toArray(new ChipComponent[]{}));
 	}
-
+	
 	protected void updateAvailableItems()
 	{
 		final List<T> availableItems = new ArrayList<>(this.allAvailableItems);
 		availableItems.removeAll(this.getValue());
 		this.cbAvailableItems.setItems(availableItems);
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 *
@@ -224,24 +224,24 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		Objects.requireNonNull(items);
 		this.allAvailableItems.clear();
 		this.allAvailableItems.addAll(items);
-
+		
 		// Remove selected values that are not in allAvailableItems
 		final Collection<T> values = new ArrayList<>(this.getValue());
 		values.removeIf(v -> !this.allAvailableItems.contains(v));
 		this.updateValues(values, false);
-
+		
 		// Force UI update here to ensure everything (selected + available) is shown correctly
 		this.updateUI();
 	}
-
+	
 	///////////////////////////////////////////////////////////////////////////
 	// setters + getters //
 	///////////////////////
-
+	
 	/*
 	 * Chips Supplier
 	 */
-
+	
 	/**
 	 * Returns the current supplier for creating new {@link ChipComponent ChipComponents}
 	 *
@@ -251,7 +251,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	{
 		return this.chipsSupplier;
 	}
-
+	
 	/**
 	 * @see ChipComboBox#setChipsSupplier(Supplier)
 	 *
@@ -263,7 +263,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		this.setChipsSupplier(chipsSupplier);
 		return this;
 	}
-
+	
 	/**
 	 * Sets the supplier for creating new {@link ChipComponent ChipComponents}
 	 *
@@ -274,11 +274,11 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	{
 		this.chipsSupplier = Objects.requireNonNull(chipsSupplier);
 	}
-
+	
 	/*
 	 * All available items
 	 */
-
+	
 	/**
 	 * Get all available items, that can potentially get selected
 	 *
@@ -288,71 +288,71 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	{
 		return new ArrayList<>(this.allAvailableItems);
 	}
-
+	
 	public ChipComboBox<T> withAllAvailableItems(final Collection<T> allAvailableItems)
 	{
 		this.setItems(allAvailableItems);
-
+		
 		return this;
 	}
-
+	
 	/*
 	 * Label (of the ComboBox)
 	 */
-
+	
 	public String getLabel()
 	{
 		return this.cbAvailableItems.getLabel();
 	}
-
+	
 	public ChipComboBox<T> withLabel(final String label)
 	{
 		this.setLabel(label);
 		return this;
 	}
-
+	
 	public void setLabel(final String label)
 	{
 		Objects.requireNonNull(label);
 		this.cbAvailableItems.setLabel(label);
 	}
-
+	
 	/*
 	 * Placeholder (of the ComboBox)
 	 */
-
+	
 	public String getPlaceholder()
 	{
 		return this.cbAvailableItems.getPlaceholder();
 	}
-
+	
 	public ChipComboBox<T> withPlaceholder(final String placeholder)
 	{
 		this.setPlaceholder(placeholder);
 		return this;
 	}
-
+	
 	public void setPlaceholder(final String placeholder)
 	{
 		Objects.requireNonNull(placeholder);
 		this.cbAvailableItems.setPlaceholder(placeholder);
 	}
-
+	
 	/*
 	 * FullComboBoxWidth
 	 */
-
+	
 	public ChipComboBox<T> withFullComboBoxWidth()
 	{
 		return this.withFullComboBoxWidth(true);
 	}
-
+	
 	public ChipComboBox<T> withFullComboBoxWidth(final boolean useFullWidth)
 	{
 		this.setFullComboBoxWidth(useFullWidth);
 		return this;
 	}
-
+	
 	public void setFullComboBoxWidth(final boolean useFullWidth)
 	{
 		if(useFullWidth)
@@ -364,11 +364,11 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 			this.cbAvailableItems.setWidth(null);
 		}
 	}
-
+	
 	/*
 	 * Item Label generator
 	 */
-
+	
 	/**
 	 * Sets the item label generator used by the individual {@link ChipComponent}s.
 	 *
@@ -383,7 +383,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 			chipComp.updateTextFromItemLabelGenerator();
 		});
 	}
-
+	
 	/**
 	 * Sets the item label generator used by the individual {@link ChipComponent}s. Equal to setChipItemLabelGenerator,
 	 * but allows in-line usage for easier component creation.
@@ -395,7 +395,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		this.setChipItemLabelGenerator(generator);
 		return this;
 	}
-
+	
 	/**
 	 * Convenience method, which sets the item label generator used by *BOTH* {@link ComboBox} and the
 	 * {@link ChipComponent}s.
@@ -407,7 +407,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		this.cbAvailableItems.setItemLabelGenerator(generator);
 		this.setChipItemLabelGenerator(generator);
 	}
-
+	
 	/**
 	 * Convenience method, which sets the item label generator used by *BOTH* {@link ComboBox} and the
 	 * {@link ChipComponent}s. Identical with setItemLabelGenerator, but allows in-line usage for easier component
@@ -420,28 +420,27 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 		this.setItemLabelGenerator(generator);
 		return this;
 	}
-
+	
 	/*
 	 * Other
 	 */
-
+	
 	@Override
 	public void setReadOnly(final boolean readOnly)
 	{
 		super.setReadOnly(readOnly);
-
+		
 		this.cbAvailableItems.setReadOnly(readOnly);
 		this.selectedComponents.forEach(comp -> comp.setReadonly(readOnly));
 	}
-
+	
 	@Override
 	public void setRequiredIndicatorVisible(final boolean requiredIndicatorVisible)
 	{
 		super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-
+		
 		this.cbAvailableItems.setRequiredIndicatorVisible(requiredIndicatorVisible);
 	}
-
 	
 	@Override
 	public void setValue(final Collection<T> value)
@@ -452,7 +451,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	/*
 	 * UI-Components
 	 */
-
+	
 	/**
 	 * Returns the {@link ComboBox} which contains the available items.<br/>
 	 * NOTE: If the contents of the {@link ComboBox} are modified from the outside this component may break
@@ -463,7 +462,7 @@ public class ChipComboBox<T> extends AbstractCompositeField<VerticalLayout, Chip
 	{
 		return this.cbAvailableItems;
 	}
-
+	
 	/**
 	 * Returns the {@link FlexLayout} with the select items (as {@link ChipComponent}s).<br/>
 	 * NOTE: If the contents of the {@link FlexLayout} are modified from the outside this component may break


### PR DESCRIPTION
Fixes #15 

I have overridden the setValue method and pass a new empty array list in the super constructor.